### PR TITLE
Allow to compile using NDK 22

### DIFF
--- a/shared/register.hpp
+++ b/shared/register.hpp
@@ -30,7 +30,8 @@ namespace custom_types {
             else {
                 // Create our type
                 auto type = ::custom_types::name_registry<T>::get();
-                if constexpr (::custom_types::has_func_register<T, void(std::vector<::custom_types::field_info*>&, std::vector<::custom_types::field_info*>&, std::vector<::custom_types::method_info*>&)>::value) {
+
+                if constexpr (::custom_types::has_func_register<T, void(std::vector<::custom_types::field_info*>&, std::vector<::custom_types::field_info*>&, std::vector<::custom_types::method_info*>&)>) {
                     ClassWrapper* classWrapper = new ClassWrapper(type);
                     // We need to determine the vtable size.
                     classWrapper->createClass(sizeof(T));
@@ -42,7 +43,7 @@ namespace custom_types {
                     classes.push_back(classWrapper);
                     return classWrapper;
                 } else {
-                    static_assert(::custom_types::has_func_register<T, void(std::vector<::custom_types::field_info*>&, std::vector<::custom_types::field_info*>&, std::vector<::custom_types::method_info*>&)>::value, "Must have a REGISTER_FUNCTION within the type!");
+                    static_assert(::custom_types::has_func_register<T, void(std::vector<::custom_types::field_info*>&, std::vector<::custom_types::field_info*>&, std::vector<::custom_types::method_info*>&)>, "Must have a REGISTER_FUNCTION within the type!");
                 }
             }
             return nullptr;

--- a/shared/types.hpp
+++ b/shared/types.hpp
@@ -208,8 +208,8 @@ namespace custom_types {
 
     template<typename T, typename Ret, typename... Args>
     constexpr bool has_func_register = requires(const T& t) {
-        t.._register(std::declval<Args>()...);
-    }
+        t._register(std::declval<Args>()...);
+    };
 
     #elif __has_include(<experimental/type_traits>)
     #include <experimental/type_traits>


### PR DESCRIPTION
This PR does allow compiling the project itself using NDK 22. However, there are some problems:
1. This requires PR sc2ad/beatsaber-hook#80 to be merged, as without the PR it fails to compile in my testing
2. The macros do not show a compile error however they do fail to compile if another project uses them. The errors in my testing are the following:
```
./extern\custom-json-data/shared/JSONWrapper.h:14:1: error: C++ requires a type specifier for all declarations
DECLARE_CLASS_CODEGEN(CustomJSONData, JSONWrapper, Il2CppObject,
^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
./extern\custom-types/shared/macros.hpp:104:32: note: expanded from macro 'DECLARE_CLASS_CODEGEN'
        friend ::custom_types::has_func_register<name, void*>; \
``` 
```
In file included from E:/SSDUse/ProgrammingProjects/CLionProjects/SomeProject/src/CustomTypeFile.cpp:16:
./extern\custom-json-data/shared/CustomBeatmapData.h:17:5: error: no template named 'false_t' in namespace 'custom_types'; did you mean simply 'false_t'?
    DECLARE_CTOR(ctor, int numberOfLines);
    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
./extern\custom-types/shared/macros.hpp:280:25: note: expanded from macro 'DECLARE_CTOR'
void name(__VA_ARGS__); \
                        ^
./extern\custom-types/shared/macros.hpp:263:27: note: expanded from macro '\
__CREATE_METHOD_WRAPPER'
            static_assert(::custom_types::false_t<memberPtr>, "Must define either an instance or a static method! Could not match either!"); \
                          ^~~~~~~~~~~~~~~~
./extern\custom-types/shared/macros.hpp:107:9: note: expanded from macro 'DECLARE_CLASS_CODEGEN'
        impl \
        ^~~~
./extern\beatsaber-hook/shared/config/../utils/utils.h:186:47: note: 'false_t' declared here
template <class...> constexpr std::false_type false_t{};
```

## These two issues will have to be dealt with before this PR can be merged, unless it will be merged and fixed later.