### PR TITLE
Default methodInfo slot to 'invalid slot' value

### DIFF
--- a/shared/types.hpp
+++ b/shared/types.hpp
@@ -64,6 +64,7 @@ namespace custom_types {
             info->methodPointer = methodPointer();
             info->name = csharpName();
             info->return_type = returnType();
+            info->slot = 0xffff;
             auto ps = params();
             info->parameters_count = ps.size();
             auto* paramList = reinterpret_cast<ParameterInfo*>(calloc(ps.size(), sizeof(ParameterInfo)));

--- a/shared/types.hpp
+++ b/shared/types.hpp
@@ -64,7 +64,7 @@ namespace custom_types {
             info->methodPointer = methodPointer();
             info->name = csharpName();
             info->return_type = returnType();
-            info->slot = 0xffff;
+            info->slot = kInvalidIl2CppMethodSlot;
             auto ps = params();
             info->parameters_count = ps.size();
             auto* paramList = reinterpret_cast<ParameterInfo*>(calloc(ps.size(), sizeof(ParameterInfo)));


### PR DESCRIPTION
The `slot` value in a method info should default to `0xffff` instead of 0. This makes it play correctly when used with UnityEvents & UnityActions when these methods get carried over from the editor.