### PR TITLE
Bump bs hook dependency

### DIFF
--- a/qpm.shared.json
+++ b/qpm.shared.json
@@ -52,14 +52,14 @@
     {
       "dependency": {
         "id": "beatsaber-hook",
-        "versionRange": "=4.0.1",
+        "versionRange": "=4.0.2",
         "additionalData": {
-          "soLink": "https://github.com/sc2ad/beatsaber-hook/releases/download/v4.0.1/libbeatsaber-hook_4_0_1.so",
-          "debugSoLink": "https://github.com/sc2ad/beatsaber-hook/releases/download/v4.0.1/debug_libbeatsaber-hook_4_0_1.so",
-          "branchName": "version/v4_0_1"
+          "soLink": "https://github.com/sc2ad/beatsaber-hook/releases/download/v4.0.1/libbeatsaber-hook_4_0_2.so",
+          "debugSoLink": "https://github.com/sc2ad/beatsaber-hook/releases/download/v4.0.1/debug_libbeatsaber-hook_4_0_2.so",
+          "branchName": "version/v4_0_2"
         }
       },
-      "version": "4.0.1"
+      "version": "4.0.2"
     },
     {
       "dependency": {

--- a/qpm.shared.json
+++ b/qpm.shared.json
@@ -54,8 +54,8 @@
         "id": "beatsaber-hook",
         "versionRange": "=4.0.2",
         "additionalData": {
-          "soLink": "https://github.com/sc2ad/beatsaber-hook/releases/download/v4.0.1/libbeatsaber-hook_4_0_2.so",
-          "debugSoLink": "https://github.com/sc2ad/beatsaber-hook/releases/download/v4.0.1/debug_libbeatsaber-hook_4_0_2.so",
+          "soLink": "https://github.com/sc2ad/beatsaber-hook/releases/download/v4.0.2/libbeatsaber-hook_4_0_2.so",
+          "debugSoLink": "https://github.com/sc2ad/beatsaber-hook/releases/download/v4.0.2/debug_libbeatsaber-hook_4_0_2.so",
           "branchName": "version/v4_0_2"
         }
       },


### PR DESCRIPTION
custom types is lagging behind with the bs hook version which causes 2 different versions to be needed when using mods